### PR TITLE
SEO additions for site description and Twitter cards

### DIFF
--- a/docs/politics.md
+++ b/docs/politics.md
@@ -203,7 +203,7 @@ Many disagreements over whether or not defense of personal property is justified
 
 ## Stock Buybacks
 
-Stock buybacks are sometimes characterized as being greedy, benefitting stockholders over employees, or as choosing to avoid investment into research & development. This is largely a fiction spun by the financially illiterate. [TBC]
+Stock buybacks are sometimes characterized as being greedy, benefitting stockholders over employees, or as choosing to avoid research into research & development. This is largely a fiction spun by the financially illiterate. [TBC]
 
 Unfortunately, some public figures (e.g. [Alexandria Ocasio-Cortez](https://en.wikipedia.org/wiki/Alexandria_Ocasio-Cortez)) seem to be ignorant on these points.
 

--- a/docs/politics.md
+++ b/docs/politics.md
@@ -195,7 +195,7 @@ Many disagreements over whether or not defense of personal property is justified
 
 ## Stock Buybacks
 
-Stock buybacks are sometimes characterized as being greedy, benefitting stockholders over employees, or as choosing to avoid research into research & development. This is largely a fiction spun by the financially illiterate. [TBC]
+Stock buybacks are sometimes characterized as being greedy, benefitting stockholders over employees, or as choosing to avoid investment into research & development. This is largely a fiction spun by the financially illiterate. [TBC]
 
 Unfortunately, some public figures (e.g. [Alexandria Ocasio-Cortez](https://en.wikipedia.org/wiki/Alexandria_Ocasio-Cortez)) seem to be ignorant on these points.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -95,6 +95,7 @@ module.exports = {
     colorMode: {
       defaultMode: 'dark',
     },
+    image: 'https://static-cdn.jtvnw.net/jtv_user_pictures/destiny-profile_image-951fd53950bc2f8b-300x300.png',
   },
   presets: [
     [

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -95,7 +95,7 @@ module.exports = {
     colorMode: {
       defaultMode: 'dark',
     },
-    image: 'https://static-cdn.jtvnw.net/jtv_user_pictures/destiny-profile_image-951fd53950bc2f8b-300x300.png',
+    image: 'https://www.destiny.gg/favicon-196x196.png',
     metadatas: [
       {name: 'twitter:card', content: 'summary'},
     ],

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -8,6 +8,9 @@ module.exports = {
   favicon: 'img/favicon.ico',
   organizationName: 'destinypositions', // Usually your GitHub org/user name.
   projectName: 'destinypositions', // Usually your repo name.
+  customFields: {
+    metaDescription: 'Steven (Destiny) Bonnell II is a professional streamer, primarily playing games, but will often venture off into other topics, including but not limited to: philosophy, youtube videos, music and all sorts of wonderful pseudo-intellectualism.',
+  },
   themeConfig: {
     // Vanilla settings
     navbar: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -96,6 +96,9 @@ module.exports = {
       defaultMode: 'dark',
     },
     image: 'https://static-cdn.jtvnw.net/jtv_user_pictures/destiny-profile_image-951fd53950bc2f8b-300x300.png',
+    metadatas: [
+      {name: 'twitter:card', content: 'summary'},
+    ],
   },
   presets: [
     [

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -66,7 +66,7 @@ function Home() {
   const {siteConfig = {}} = useDocusaurusContext();
   return (
     <Layout
-      title={`${siteConfig.title}`}
+      title={siteConfig.title}
       description="Description will go into a meta tag in <head />">
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -63,8 +63,7 @@ function Feature({num, title, iconName, description}) {
 }
 
 function Home() {
-  const context = useDocusaurusContext();
-  const {siteConfig = {}} = context;
+  const {siteConfig = {}} = useDocusaurusContext();
   return (
     <Layout
       title={`${siteConfig.title}`}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -66,7 +66,6 @@ function Home() {
   const {siteConfig = {}} = useDocusaurusContext();
   return (
     <Layout
-      title={siteConfig.title}
       description={siteConfig.customFields.metaDescription}>
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -67,7 +67,7 @@ function Home() {
   return (
     <Layout
       title={siteConfig.title}
-      description="Description will go into a meta tag in <head />">
+      description={siteConfig.customFields.metaDescription}>
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">
           <img src={useBaseUrl('img/dgg-logo.svg')} height="100px" />


### PR DESCRIPTION
Changes:
1. Copied the site description from https://destiny.gg for the index page of positions.destiny.gg (This can be changed by changing the `customFields.metaDescription` key in `docusaurus.config.js`
2. Added a meta image for social media sharing like on Twitter (This can be changed by changing the `themeConfig.image` key in `docusaurus.config.js`
3. Changed site title on index page to just be "My Positions" instead of "My Positions | My Positions"

## Twitter Card Screenshots
Before:
<img width="463" alt="Screen Shot 2021-03-03 at 11 46 43 AM" src="https://user-images.githubusercontent.com/6654122/109846650-65931a80-7c1c-11eb-8520-3fd8aff72022.png">
After:
<img width="452" alt="Screen Shot 2021-03-03 at 12 32 42 PM" src="https://user-images.githubusercontent.com/6654122/109846842-92473200-7c1c-11eb-8d7e-a443e731c5c6.png">

For specific pages the title/description comes from the document markdown description field
Before:
<img width="451" alt="Screen Shot 2021-03-03 at 12 34 11 PM" src="https://user-images.githubusercontent.com/6654122/109847052-c7538480-7c1c-11eb-8b9d-b6a3625170cc.png">
After:
<img width="453" alt="Screen Shot 2021-03-03 at 12 33 51 PM" src="https://user-images.githubusercontent.com/6654122/109847104-d2a6b000-7c1c-11eb-96a3-1c2210389324.png">

