### PR TITLE
Headless CMS

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -5,10 +5,6 @@ sidebar_label: About
 description: Positions of Steven "Destiny" Bonnell
 slug: /
 ---
-TEST TEST TEST
-
-
-
 As a content creator, I am often misrepresented. Sometimes, this is by people who disagree with me and want to attack a [straw man](https://en.wikipedia.org/wiki/Straw_man). But at the same time, part of the problem is that in order to find out what I believe, you might have to sit through an hour long YouTube video in which I get into the nitty-gritty details of an issue. Not ideal.
 
 This problem has only gotten worse over time. I have been streaming for over 10 years, and a good chunk of people out there may have unfavorable opinions of me based on positions that I don't actually hold. It is exhausting to have to repeatedly clarify myself and stop the spread of misinformation.

--- a/docs/about.md
+++ b/docs/about.md
@@ -5,6 +5,9 @@ sidebar_label: About
 description: Positions of Steven "Destiny" Bonnell
 slug: /
 ---
+TEST TEST TEST
+
+
 
 As a content creator, I am often misrepresented. Sometimes, this is by people who disagree with me and want to attack a [straw man](https://en.wikipedia.org/wiki/Straw_man). But at the same time, part of the problem is that in order to find out what I believe, you might have to sit through an hour long YouTube video in which I get into the nitty-gritty details of an issue. Not ideal.
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -118,5 +118,9 @@ module.exports = {
       src: 'https://kit.fontawesome.com/1932a73877.js',
       crossorigin: 'anonymous',
     },
+    {
+      src: 'https://identity.netlify.com/v1/netlify-identity-widget.js',
+      crossorigin: 'anonymous',
+    },
   ],
 };

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -120,7 +120,6 @@ module.exports = {
     },
     {
       src: 'https://identity.netlify.com/v1/netlify-identity-widget.js',
-      crossorigin: 'anonymous',
     },
   ],
 };

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import clsx from 'clsx';
 import Layout from '@theme/Layout';
 import Link from '@docusaurus/Link';
@@ -65,15 +65,19 @@ function Feature({num, title, iconName, description}) {
 function Home() {
   const {siteConfig = {}} = useDocusaurusContext();
 
-  // if (window?.netlifyIdentity) {
-  //   window.netlifyIdentity.on('init', user => {
-  //     if (!user) {
-  //       window.netlifyIdentity.on('login', () => {
-  //         document.location.href = '/admin'
-  //       });
-  //     }
-  //   });
-  // }
+  useEffect(() => {
+    function handleInitializeNetflifyUser() {
+      if (!user) {
+        window.netlifyIdentity.on('login', () => {
+          document.location.href = '/admin'
+        });
+      }
+    }
+
+    return () => {
+      window.netflifyIdentity.off('init', handleInitializeNetlifyUser);
+    };
+  }, []);
 
   return (
     <Layout

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -75,7 +75,7 @@ function Home() {
     }
 
     return () => {
-      window.netflifyIdentity.off('init', handleInitializeNetlifyUser);
+      window.netlifyIdentity.off('init', handleInitializeNetlifyUser);
     };
   }, []);
 

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -65,15 +65,15 @@ function Feature({num, title, iconName, description}) {
 function Home() {
   const {siteConfig = {}} = useDocusaurusContext();
 
-  if (window.netlifyIdentity) {
-    window.netlifyIdentity.on('init', user => {
-      if (!user) {
-        window.netlifyIdentity.on('login', () => {
-          document.location.href = '/admin'
-        });
-      }
-    });
-  }
+  // if (window?.netlifyIdentity) {
+  //   window.netlifyIdentity.on('init', user => {
+  //     if (!user) {
+  //       window.netlifyIdentity.on('login', () => {
+  //         document.location.href = '/admin'
+  //       });
+  //     }
+  //   });
+  // }
 
   return (
     <Layout

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -64,6 +64,17 @@ function Feature({num, title, iconName, description}) {
 
 function Home() {
   const {siteConfig = {}} = useDocusaurusContext();
+
+  if (window.netlifyIdentity) {
+    window.netlifyIdentity.on('init', user => {
+      if (!user) {
+        window.netlifyIdentity.on('login', () => {
+          document.location.href = '/admin'
+        });
+      }
+    });
+  }
+
   return (
     <Layout
       description={siteConfig.customFields.metaDescription}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -66,13 +66,14 @@ function Home() {
   const {siteConfig = {}} = useDocusaurusContext();
 
   useEffect(() => {
-    function handleInitializeNetflifyUser() {
+    function handleInitializeNetlifyUser() {
       if (!user) {
         window.netlifyIdentity.on('login', () => {
           document.location.href = '/admin'
         });
       }
     }
+    window.netflifyIdentity.on('init', handleInitializeNetlifyUser);
 
     return () => {
       window.netlifyIdentity.off('init', handleInitializeNetlifyUser);

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -66,6 +66,7 @@ function Home() {
   const {siteConfig = {}} = useDocusaurusContext();
 
   useEffect(() => {
+    // after a netlify user has been set up redirect them to the admin page
     function handleInitializeNetlifyUser() {
       if (!user) {
         window.netlifyIdentity.on('login', () => {
@@ -73,10 +74,14 @@ function Home() {
         });
       }
     }
-    window.netflifyIdentity.on('init', handleInitializeNetlifyUser);
+    if (window.netlifyIdentity) {
+      window.netlifyIdentity.on('init', handleInitializeNetlifyUser);
+    }
 
     return () => {
-      window.netlifyIdentity.off('init', handleInitializeNetlifyUser);
+      if (window.netlifyIdentity) {
+        window.netlifyIdentity.off('init', handleInitializeNetlifyUser);
+      }
     };
   }, []);
 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,0 +1,19 @@
+backend:
+  name: git-gateway
+  branch: main
+
+publish_mode: editorial_workflow
+
+media_folder: 'static/img/uploads'
+public_folder: '/img/uploads'
+
+collections:
+  - name: 'post'
+    label: 'Post'
+    folder: 'docs'
+    create: true
+    fields:
+      - {label: 'ID', name: 'id', widget: 'string'}
+      - {label: 'Title', name: 'title', widget: 'string'}
+      - {label: 'Sidebar Label', name: 'sidebar_label', widget: 'string'}
+      - {label: 'Description', name: 'description', widget: 'string'}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: main
+  branch: headless_cms
 
 publish_mode: editorial_workflow
 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -1,6 +1,6 @@
 backend:
   name: git-gateway
-  branch: headless_cms
+  branch: main
 
 publish_mode: editorial_workflow
 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -15,6 +15,6 @@ collections:
     fields:
       - {label: 'ID', name: 'id', widget: 'string'}
       - {label: 'Title', name: 'title', widget: 'string'}
-      - {label: 'Sidebar Label', name: 'sidebar_label', widget: 'string'}
-      - {label: 'Description', name: 'description', widget: 'string'}
+      - {label: 'Sidebar Label', name: 'sidebar_label', widget: 'string', required: false}
+      - {label: 'Description', name: 'description', widget: 'string', required: false}
       - {label: 'Body', name: 'body', widget: 'markdown'}

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -17,3 +17,4 @@ collections:
       - {label: 'Title', name: 'title', widget: 'string'}
       - {label: 'Sidebar Label', name: 'sidebar_label', widget: 'string'}
       - {label: 'Description', name: 'description', widget: 'string'}
+      - {label: 'Body', name: 'body', widget: 'markdown'}

--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Content Manager</title>
+
+  <script src="https://identity.netlify.com/v1/netlify-identity-widget.js"></script>
+</head>
+<body>
+  <!-- Include the script that builds the page and powers Netlify CMS -->
+  <script src="https://unpkg.com/netlify-cms@^2.0.0/dist/netlify-cms.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Why

[Netlify CMS](https://www.netlifycms.org/) is a headless CMS that can hook up to markdown files in a GitHub repository.
This allows content to be edited through an admin portal, or through direct code changes. (Community suggestions can still be made through PR's, but meaningful additions can be edited in a CMS GUI).

<img width="1680" alt="Screen Shot 2021-03-04 at 2 38 37 PM" src="https://user-images.githubusercontent.com/6654122/110020246-59c85680-7cf7-11eb-9849-b129eae3e4c8.png">

## How

This [guide](https://www.netlifycms.org/docs/add-to-your-site/) walks through how Netlify CMS is added to the site. Which is mostly done in this PR.

Netlify CMS needs to be authorized to connect to the GitHub repo to commit changes to copy.
This is explained [here](https://www.netlify.com/blog/2016/10/27/a-step-by-step-guide-deploying-a-static-site-or-single-page-app/)
1. Create Netlify Account and Create a website (as if you were hosting it on Netlify)
2. Authorize Netlify to connect to GitHub
3. To stop Netlify from doing builds go to `Site Settings > Build & Deploy > Build Settings` and select "Stop Builds"

To add a user that can edit the site, go to `Identity` in top nav and click on "Invite Users"
This will allow you to add an email that will send an invitation linking back to the site. Here a user can set their password and be redirected to `/admin` to begin editing content.

## Using CMS

When a user goes to `/admin` page, they are met with a login for their account they set up.

Once logged in they can click on some document and see the screenshot above. Here they can edit with a nice WYSIWYG editor and see a readable preview (isn't styled like actual site, but translates markdown to make sure markdown is written correctly.

Once content is ready to be published, it can be moved to a ready state, and published. This will create a commit on the main branch of GitHub which will trigger a new deploy.