### PR TITLE
Added description to current events page

### DIFF
--- a/docs/current_events.md
+++ b/docs/current_events.md
@@ -1,6 +1,7 @@
 ---
 id: current_events
 title: Current Events
+description: My arguments about recent events and the prevailing narratives around them.
 ---
 
 ## Kyle Rittenhouse ("mowing down protestors")


### PR DESCRIPTION
Adding a description field at the top of markdown files controls what shows up when the page is shared on social media.

Currently if someone shares the current events page on twitter, the text is whatever the first header of the page is.

<img width="442" alt="Screen Shot 2021-03-05 at 12 48 11 PM" src="https://user-images.githubusercontent.com/6654122/110154481-4a5a1380-7db2-11eb-80ff-851e1533ae25.png">

If you want to control what the text is, adding a description to the markdown file will overwrite the text in the twitter card.

```
---
id: current_events
title: Current Events
description: My arguments about recent events and the prevailing narratives around them.
---
```

<img width="457" alt="Screen Shot 2021-03-05 at 12 54 54 PM" src="https://user-images.githubusercontent.com/6654122/110154665-7ffefc80-7db2-11eb-98d1-87e1bfe6b386.png">
