### PR TITLE
Top Navigation links' highlighting fix

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -22,31 +22,31 @@ module.exports = {
       items: [
         {
           to: 'docs/',
-          activeBasePath: 'docs',
+          activeBaseRegex: 'docs/$',
           label: 'About',
           position: 'left',
         },
         {
           to: 'docs/current_events',
-          activeBasePath: 'docs',
+          activeBasePath: 'docs/current_events',
           label: 'Current Events',
           position: 'left',
         },
         {
           to: 'docs/politics',
-          activeBasePath: 'docs',
+          activeBasePath: 'docs/politics',
           label: 'Politics',
           position: 'left',
         },
         {
           to: 'docs/philosophy',
-          activeBasePath: 'docs',
+          activeBasePath: 'docs/philosophy',
           label: 'Philosophy',
           position: 'left',
         },
         {
           to: 'docs/personal',
-          activeBasePath: 'docs',
+          activeBasePath: 'docs/personal',
           label: 'Personal',
           position: 'left',
         },


### PR DESCRIPTION
When a user is on any of the document pages, all top nav items are marked active and highlighted.
This is because the `activeBasePath` in `docusaurus.config.js` for each nav item is set to `/docs`.

Now nav items are only highlighted if the user is on that page currently or they hover over the element.

![Screen Shot 2021-03-07 at 9 09 22 AM](https://user-images.githubusercontent.com/6654122/110242610-d4c28480-7f24-11eb-8bba-6073597a0148.png)
