### PR TITLE
added google analytics

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -111,6 +111,10 @@ module.exports = {
     metadatas: [
       {name: 'twitter:card', content: 'summary'},
     ],
+    googleAnalytics: {
+      trackingID: 'UA-37443504-1',
+      anonymizeIP: true
+    },
   },
   presets: [
     [


### PR DESCRIPTION
Adds the google analytics script to the page's header.

This PR already has the same google analytics token as https://destiny.gg.
If you want to use the same property, a new View will have to be made with the https://positions.destiny.gg URL.

If you want to track users between destiny.gg and positions.destiny.gg there's probably a way to do it but it looks annoying.

https://developers.google.com/analytics/devguides/collection/gajs/gaTrackingSite