### PR TITLE
Prevent the build status from being "stuck" for pull requests

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,6 @@
 name: Build-Test
 
-on: 
-  push:
-  pull_request:
-    types: [opened, reopened]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
This reverts commit 315291911a55e528a9046ca321bbfd6bf67ddafb.

The current criteria for building pull requests prevents them from being rebuilt when the author pushes updates to their branch. *I think* this is the issue as seen in #78.

The issue is that it's waiting for a build related to new commits pushed by the author, but no build is being scheduled because the current criteria prevents it. The current criteria will only schedule builds when pull requests are *opened* or *re-opened* by external contributors. This reverts it back to the old criteria which will rebuild whenever authors push new commits to pull requests.

This does mean that pull requests created from branches local to the current repo will build twice which is what I think #58 tried to prevent. I'm not sure what the best way to fix that is.

CC: @ILiedAboutCake, since they tried to fix the original issue in #58.

Feel free to close if this is the behavior you want. But hopefully now at least you know why it is what it is!