### PR TITLE
cleanup action for faster ci builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,12 +8,8 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
-        with:
-          node-version: '14'
-      - run: yarn install
 
-      - name: Install Node Packages
+      - name: Yarn Install
         run: yarn install --frozen-lockfile
 
       - name: Build Local


### PR DESCRIPTION
* Ubuntu-20.04 contains node 14, no reason to configure it.
* Yarn install only needs to run once