### PR TITLE
Enable Caching of Yarn Packages in Build Process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,8 +9,21 @@ jobs:
       - name: Checkout Repo
         uses: actions/checkout@v2
 
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Use Yarn Cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
       - name: Yarn Install
-        run: yarn install --frozen-lockfile
+        run: yarn install --prefer-offline --frozen-lockfile
 
       - name: Build Local
         run: yarn run build


### PR DESCRIPTION
Speed up reproducible ci builds because I have ADHD and must go fast 🚀 

* https://github.com/actions/cache/blob/main/examples.md#node---yarn
* https://stackoverflow.com/questions/61010294/how-to-cache-yarn-packages-in-github-actions/62244232#62244232