### PR TITLE
Fix site title on home page

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -66,6 +66,7 @@ function Home() {
   const {siteConfig = {}} = useDocusaurusContext();
   return (
     <Layout
+      title='Home'
       description={siteConfig.customFields.metaDescription}>
       <header className={clsx('hero hero--primary', styles.heroBanner)}>
         <div className="container">


### PR DESCRIPTION
The <title> tag is blank on the home page.
This is bad for SEO, results in raw url as tab label in browser, and breaks social media cards.

Docusaurus introduced a bug between alpha 70 and 72 (which this repo updated to recently) so that not including the title prop in Layout components results in a blank <title> tag on the page. Before it would default to the global site title set in `docusaurus.config.js`

Easiest fix seems to be to just re-add a title to the home page