### PR TITLE
Updates GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,18 +10,17 @@ jobs:
       matrix:
         node: [ 16 ]
     steps:
-      - name: Checkout Repo
-        uses: actions/checkout@v3
-
-      - name: Setup node
+      - uses: actions/checkout@v3
+      -
+        name: Setup node
         uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node }}
           check-latest: true
           cache: 'yarn'
-
-      - name: Install dependencies
+      -
+        name: Install dependencies
         run: yarn install --prefer-offline --frozen-lockfile
-
-      - name: Build
+      -
+        name: Build
         run: yarn run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ 16, 18 ]
+        node: [ 16 ]
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,12 @@
 name: Build-Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,27 +3,25 @@ name: Build-Test
 on: [push, pull_request]
 
 jobs:
+
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [ 16, 18 ]
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Use Yarn Cache
-        uses: actions/cache@v2
-        id: yarn-cache
+      - name: Setup node
+        uses: actions/setup-node@v2
         with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          node-version: ${{ matrix.node }}
+          check-latest: true
+          cache: 'yarn'
 
-      - name: Yarn Install
+      - name: Install dependencies
         run: yarn install --prefer-offline --frozen-lockfile
 
-      - name: Build Local
+      - name: Build
         run: yarn run build


### PR DESCRIPTION
- Just use `ubuntu-latest`, much less maintenance
- `actions/checkout@v3`
- `actions/setup-node@v2` (builtin `actions/cache`)
- Multiple version matrix - I would've enabled for Node 18 Current as well as LTS, but 18 is currently failing to build.
- Only run for `main` changes, saving unnecessary duplicate runs.