### PR TITLE
Bash from $PATH instead of only bin

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 npm run start


### PR DESCRIPTION
Searches for `bash` in `$PATH` rather than only from `/bin` which allows flexibility in its source location. This is compatible with `bash` that's also in `/bin` for almost all setups.

This fixes the issue of using newer `bash` installations from package managers that don't overwrite system defaults.