### PR TITLE
feature(docs): Bold links look better on those strong links

### DIFF
--- a/docs/personal.md
+++ b/docs/personal.md
@@ -21,11 +21,11 @@ Melina and I are currently in an open/poly relationship. We treat each other as 
 
 ## Links
 
-* [YouTube](https://www.youtube.com/user/destiny/)
-* [Instagram](https://www.instagram.com/destiny/)
-* [Twitter](https://www.twitter.com/TheOmniLiberal)
-* [Rumble](https://www.rumble.com/Destiny)
-* [Kick](https://www.kick.com/destiny)
-* [Reddit](https://www.reddit.com/r/Destiny/)
-* [Email](mailto:contact@destiny.gg)
-* [Wikipedia](https://en.wikipedia.org/wiki/Destiny_(streamer))
+- **[YouTube](https://www.youtube.com/user/destiny/)**                                                                                                                                          │
+- **[Instagram](https://www.instagram.com/destiny/)**                                                                                                                                           │
+- **[Twitter](https://www.twitter.com/TheOmniLiberal)**                                                                                                                                         │
+- **[Rumble](https://www.rumble.com/Destiny)**                                                                                                                                                  │
+- **[Kick](https://www.kick.com/destiny)**                                                                                                                                                      │
+- **[Reddit](https://www.reddit.com/r/Destiny/)**                                                                                                                                               │
+- **[Email](mailto:contact@destiny.gg)**                                                                                                                                                        │
+- **[Wikipedia](https://en.wikipedia.org/wiki/Destiny_(streamer))**

--- a/docs/personal.md
+++ b/docs/personal.md
@@ -17,7 +17,7 @@ I have a son called Nathaniel with my ex-girlfriend, Rachel. My ex-girlfriend an
 
 [Melina](https://www.twitch.tv/melina) is my wife. We met in New Zealand when she was 20 years old and I was 30 years old.
 
-Melina and I are currently in an open/poly relationship. We treat each other as primary partners, though we may pursue other sexual/romantic relationships as well.8
+Melina and I are currently in an open/poly relationship. We treat each other as primary partners, though we may pursue other sexual/romantic relationships as well.
 
 ## Links
 


### PR DESCRIPTION
# Feature request.
The links on the Personal docs page have some good formatting, but we can do better. I asked Chat GPT 3.5 what would make the markdown look cool. Chat GPT recommended we use bold text for the links. I agree with the robot. Can we make this happen?

**Old Links**
![image](https://user-images.githubusercontent.com/4871249/226459061-99e9932c-67d9-4286-8727-243122787b50.png)
**New Links**
![image](https://user-images.githubusercontent.com/4871249/226458951-7e30d309-41a4-4925-867d-9eb3096f2d88.png)
**Full Page**
![image](https://user-images.githubusercontent.com/4871249/226459862-e7caeca2-d0ad-4efe-9ae7-4ccec8af57d7.png)


# Changes
- Updated links
- Removed a dangling string at the end of a sentence. 

# Authors
- Me _(DevOps Engineer)_