### PR TITLE
Create preview build for PRs

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,38 @@
+name: Deploy PR previews
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-20.04
+    env:
+      BASE_URL: "${{ github.event.repository.name }}/pr-preview/pr-${{ github.event.number }}"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: 'yarn'
+
+      - name: Install and build
+        run: |
+          yarn install --frozen-lockfile
+          yarn run build
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./build/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -2,7 +2,7 @@ module.exports = {
   title: 'My Positions',
   tagline: 'Find out what I actually believe.',
   url: 'https://positions.destiny.gg/',
-  baseUrl: '/',
+  baseUrl: process.env.GITHUB_ACTIONS ? `${process.env.BASE_URL}/` : "/",
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
   favicon: 'img/favicon.ico',


### PR DESCRIPTION
This creates an action that builds and deploys the site to GitHub pages which can be accessed with a temporary link 

<https://nathanaelrea.github.io/destinypositions/pr-preview/pr-2/>

You can check out what it would look like from the PR on my repo:

<https://github.com/NathanaelRea/destinypositions/pull/2>

For this action to work, you need to
- Add the branch `gh-pages` to the repo
- Set `gh-pages` as the `Deploy from a branch` in `Settings > Pages`
- Grant actions read/write access in `Settings > Actions > General > Workflow permissions`

You can read more about the action here: <https://github.com/rossjrw/pr-preview-action>